### PR TITLE
update to hsl-gen 0.6.0, darker gradient in dark mode

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -76,11 +76,11 @@ docstyle.setProperty('--active-dark', colorScheme.huehsl);
 docstyle.setProperty('--background-color-light', colorScheme.huehsl);
 docstyle.setProperty('--background-color-dark', colorScheme.darkhuehsl);
 docstyle.setProperty('--complement', colorScheme.analhsl);
+docstyle.setProperty('--complementdark', colorScheme.analhsldark);
 docstyle.setProperty('--complementdarker', colorScheme.analhsldarker);
-docstyle.setProperty('--complementtext', colorScheme.analhsltext);
 docstyle.setProperty('--primary', colorScheme.comphsl);
+docstyle.setProperty('--primarydark', colorScheme.comphsldark);
 docstyle.setProperty('--primarydarker', colorScheme.comphsldarker);
-docstyle.setProperty('--primarytext', colorScheme.comphsltext);
 docstyle.setProperty('--text-color-dark', colorScheme.huehsllighter);
 docstyle.setProperty('--text-color-light', colorScheme.darkhuehsldarker);
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@11ty/eleventy-plugin-bundle": "^1.0.4",
 		"@11ty/eleventy-plugin-rss": "^1.2.0",
 		"@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
-		"@famebot/hsl-gen": "^0.4.0",
+		"@famebot/hsl-gen": "^0.6.0",
 		"luxon": "^3.3.0",
 		"markdown-it-anchor": "^8.6.7"
 	}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -49,7 +49,7 @@
 		--button-border-color: var(--background-color-light);
 		--button-border-color-highlight: var(--primary);
 		
-		--rainbow-horizon: var(--background-color-dark), 64%, var(--complementdarker), 92%, var(--primarydarker)
+		--rainbow-horizon: var(--background-color-dark), 64%, var(--complementdark), 92%, var(--primarydark)
 	}
 }
 


### PR DESCRIPTION
Upstream additions to [HSL Gen](https://hsl-gen.netlify.app/) allow contrast improvements for dark mode background gradient. These improvements provide a significant legibility benefit on longer pages and for page footers. The net result is the lower half of pages in dark mode are darker.