### PR TITLE
v9.1.0-alpha.5

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.0.0-alpha.5",
+	title: "eleventeen v9.1.0-alpha.5",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -59,9 +59,9 @@
 
 			<footer>
 				{#- 🌈 Rainbow button #}
-				<button onclick="rainbow()">🌈 Rainbow Me</button>
+				<button title="wish upon a star" onclick="rainbow()">🌈 Rainbow Me</button>
 				<aside id="chromagen"></aside>
-				<span>powered by <a href="https://github.com/rdela/eleventeen">eleventeen</a></span>
+				<aside>powered by <a title="v9.1.0-alpha.5" href="https://github.com/rdela/eleventeen">eleventeen</a></aside>
 			</footer>
 
 			<!-- This page `{{ page.url | htmlBaseUrl }}` was built on {% currentBuildDate %} -->

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -60,7 +60,7 @@
 			<footer>
 				{#- 🌈 Rainbow button #}
 				<button onclick="rainbow()">🌈 Rainbow Me</button>
-				<span id="chromagen-hue"></span>
+				<aside id="chromagen"></aside>
 				<span>powered by <a href="https://github.com/rdela/eleventeen">eleventeen</a></span>
 			</footer>
 
@@ -104,7 +104,22 @@ darkPreference.addEventListener("change", e => e.matches && activateColorScheme(
 lightPreference.addEventListener("change", e => e.matches && activateColorScheme());
 activateColorScheme();
 
-document.querySelector('#chromagen-hue').innerHTML = ` H ${colorScheme.hue} C ${colorScheme.complement} H ${colorScheme.analogous} (<a href="https://chromagen.io">Chromagen</a>)`;
+document.querySelector('#chromagen').innerHTML = `<details>
+	<summary>🎨
+		<span title="hue"> H&nbsp;${colorScheme.hue} </span> 
+		<span title="complement">C&nbsp;${colorScheme.complement} </span> 
+		<span title="analogous">A&nbsp;${colorScheme.analogous}</span>
+	</summary>
+	<span title="saturation">S&nbsp;${colorScheme.saturation} </span>
+	<span title="xlight">XL&nbsp;${colorScheme.xlight} </span>
+	<span title="lighter">L+&nbsp;${colorScheme.lighter} </span>
+	<span title="lightness">L&nbsp;${colorScheme.lightness} </span>
+	<span title="midrange">M&nbsp;${colorScheme.midrange} </span>
+	<span title="lowmid">LM&nbsp;${colorScheme.lowmid} </span>
+	<span title="darkness">D&nbsp;${colorScheme.darkness} </span>
+	<span title="darker">D+&nbsp;${colorScheme.darker} </span>
+	<a href="https://chromagen.io">Chromagen</a>
+</details>`;
 }
 rainbow();
 			{% endjs %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.0.0-alpha.5",
+	"version": "9.1.0-alpha.5",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -200,6 +200,7 @@ footer {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	min-height: 7rem;
 }
 
 @media screen and (max-width: 720px) {
@@ -210,6 +211,12 @@ footer {
 	}
 }
 
+#chromagen {
+	cursor: pointer;
+	max-width: 18rem;
+	padding: 0 1rem;
+	text-align: center;
+}
 
 /* Header */
 header {


### PR DESCRIPTION
# v9.1.0-alpha.5

## feat/fix: chromagen readout

correct and improve chromagen readout. pseudo diff: 

`/_includes/layouts/base.njk`

```diff
-	span id="chromagen-hue"
+	aside id="chromagen"
- H ${colorScheme.analogous}
+ A ${colorScheme.analogous}
```

readout is now details element, 
where `<summary>` is H/C/A and disclosed contents are

```diff
+		<span title="saturation">S&nbsp;${colorScheme.saturation} </span>
+		<span title="xlight">XL&nbsp;${colorScheme.xlight} </span>
+		<span title="lighter">L+&nbsp;${colorScheme.lighter} </span>
+		<span title="lightness">L&nbsp;${colorScheme.lightness} </span>
+		<span title="midrange">M&nbsp;${colorScheme.midrange} </span>
+		<span title="lowmid">LM&nbsp;${colorScheme.lowmid} </span>
+		<span title="darkness">D&nbsp;${colorScheme.darkness} </span>
+		<span title="darker">D+&nbsp;${colorScheme.darker} </span>
+	<a href="https://chromagen.io">Chromagen</a>
```

`/public/css/index.css`

```diff
+		min-height: 7rem; /* footer {} */
+	#chromagen {
+		cursor: pointer;
+		display: inline-block;
+		max-width: 18rem;
+		padding: 0 1rem;
+		text-align: center;
+	}
```
