### PR TITLE
v9.2.2-alpha.5: refine post images + docs + lighthouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## WARNING: Here Be Canaries 🐥
 
-This starter has advanced ahead of its upstream source, [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), to boldy embrace [Eleventy v3](https://www.11ty.dev/blog/canary-eleventy-v3/) in [PR #8](https://github.com/rdela/eleventeen/pull/8).
+This starter has advanced ahead of its upstream source, [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), to boldy embrace [Eleventy v3](https://www.11ty.dev/blog/canary-eleventy-v3/) in [PR #8](https://github.com/rdela/eleventeen/pull/8) / [v9.0.0-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.0.0-alpha.5).
 
 Eleventy Base Blog is:
 
@@ -12,7 +12,7 @@ Eleventy Base Blog is:
 
 In addition to all of Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports [Rainbow Mode™](https://github.com/rdela/eleventeen/pull/1) powered by [Chromagen](https://github.com/famebot/chromagen) 🌈📓➕🎨💥
 
-Rejoicing and rainbows aside, eleventeen also makes some more subtle adjustments to Eleventy Base Blog. There are various changes in `public/css/index.css`, and in `_includes/postslist.njk`:
+Rejoicing and rainbows aside, eleventeen also adds post images in [PR #10](https://github.com/rdela/eleventeen/pull/10) / [v9.2.1-alpha.5 ](https://github.com/rdela/eleventeen/releases/tag/v9.2.1-alpha.5), refines them further in 🎈[PR #11](https://github.com/rdela/eleventeen/pull/10) / [v9.2.2-alpha.5 ](https://github.com/rdela/eleventeen/releases/tag/v9.2.2-alpha.5), and makes some more subtle adjustments to Eleventy Base Blog. There are various changes in `public/css/index.css`, and in `_includes/postslist.njk`:
  
 ```njk
 <ol reversed class="postlist" style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}">

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -8,6 +8,7 @@ let data = {
 		email: "juanita@example.com",
 		url: "https://example.org",
 	},
+	eleventeen: "v9.2.1-alpha.5",
 };
 
 export default data;

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.2.1-alpha.5",
+	title: "eleventeen v9.2.2-alpha.5",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",
@@ -8,7 +8,7 @@ let data = {
 		email: "juanita@example.com",
 		url: "https://example.org",
 	},
-	eleventeen: "v9.2.1-alpha.5",
+	eleventeen: "v9.2.2-alpha.5",
 };
 
 export default data;

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -61,7 +61,7 @@
 				{#- 🌈 Rainbow button #}
 				<button title="wish upon a star" onclick="rainbow()">🌈 Rainbow Me</button>
 				<aside id="chromagen"></aside>
-				<aside>powered by <a title="v9.2.1-alpha.5" href="https://github.com/rdela/eleventeen">eleventeen</a></aside>
+				<aside>powered by <a title="{{ metadata.eleventeen }}" href="https://github.com/rdela/eleventeen">eleventeen</a></aside>
 			</footer>
 
 			<!-- This page `{{ page.url | htmlBaseUrl }}` was built on {% currentBuildDate %} -->

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -6,13 +6,11 @@
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
 		{%- if post.data.hero and post.data.heroalt %}
 		<figure class="postlist-img"><a href="{{ post.url }}" class="postlist-link">{% image ['./', post.url, post.data.hero] | join, post.data.heroalt, [488] %}</a></figure>
+		{%- endif %}
 		<div class="postlist-text">
-		{%- endif %}
-		<a href="{{ post.url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
-		<time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate("d LLLL yyyy") }}</time>
-		{%- if post.data.hero and post.data.heroalt %}
+			<a href="{{ post.url }}" class="postlist-link ellipsize">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
+			<time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate("d LLLL yyyy") }}</time>
 		</div>
-		{%- endif %}
 	</li>
 {% endfor %}
 </ul>

--- a/content/archive/secondpost/secondpost.md
+++ b/content/archive/secondpost/secondpost.md
@@ -1,6 +1,6 @@
 ---
-title: This is my second post with a much longer title.
-description: This is a post on My Blog about leveraging agile frameworks.
+title: This is my second post with a much longer title. I love ellipsis la la la la la la la la la la la.
+description: Republishing my guest post on Ellipsize about leveraging agile frameworks to maximize ellipsization.
 date: 2018-07-04
 hero: elle-balloon-r1-t1-c2.png
 heroalt: Close-up of Elle the possum, suspended from a red balloon.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,24 @@
 [build]
 	publish = "_site"
 	command = "npm run build"
+
+[[plugins]]
+
+	# Opt-in to the Netlify Lighthouse plugin (choose one):
+
+	# 1. Go to your site on https://app.netlify.com and navigate to the Integrations tab, search for the `Lighthouse` plugin
+	# 2. Or via `npm install -D @netlify/plugin-lighthouse`
+
+	# Read more: https://github.com/netlify/netlify-plugin-lighthouse
+
+	package = "@netlify/plugin-lighthouse"
+
+	# optional, fails build when a category is below a threshold
+	[plugins.inputs.thresholds]
+		performance = 1.0
+		accessibility = 1.0
+		best-practices = 1.0
+		seo = 0.9
+
+	[plugins.inputs]
+		output_path = "reports/lighthouse/index.html"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.1-alpha.5",
+	"version": "9.2.2-alpha.5",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -270,9 +270,14 @@ header {
 }
 .postlist-item {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
 	margin-bottom: 1em;
+}
+@media screen and (max-width: 320px) {
+	.postlist-item {
+		/* moved from prev rule */
+		flex-wrap: wrap;
+	}
 }
 /* if using ol in _includes/postslist.njk */
 /* counter-increment: start-from -1;
@@ -297,7 +302,7 @@ header {
 .postlist-link {
 	font-size: 1.1875em; /* 19px /16 */
 	font-weight: 700;
-	flex-basis: calc(100% - 1.5rem);
+	flex-basis: calc(100% - 1.5rem); /* see postlist-item:before margin-left above */
 	text-underline-position: from-font;
 	text-underline-offset: 0;
 	text-decoration-thickness: 1px;
@@ -309,11 +314,28 @@ header {
 	height: 128px;
 	width: 128px;
 	object-fit: cover;
+}
+.postlist-img {
 	margin-right: 1em;
+	min-width: 128px;
 }
 .postlist-text {
 	display: flex;
 	flex-direction: column;
+	padding-bottom: 0.4375em;
+}
+.postlist-text a {
+	line-height: 1.25;
+}
+.ellipsize {
+	overflow: hidden; /* keeps the element from overflowing its parent */
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3; /* start showing ellipsis when 3rd line is reached */
+	line-clamp: 3;
+	/* implicit... */
+	/* text-overflow: ellipsis; */
+	/* white-space: normal; */
 }
 
 /* Tags */


### PR DESCRIPTION
# feat: refine post images + docs (v9.2.2-alpha.5)

- *new* post images (PR #10) in the post list now work much better on 
  smaller screen sizes. 

  + simplified hero thumb logic in postslist.njk so that 
  postlist-text always visible. 
  + `flex-wrap: wrap;` now only on postlist-item at < 320px screens. 
  + add padding-bottom to postlist-text to balance vertical center. 

- added `ellipsize` css using webkit-box and line-clamp to prevent extra long 
  post title spill/overflow, tested with secondpost.md. 

- added metadata.eleventeen for version report in footer 
  (hover over eleventeen link).