### PR TITLE
feat: support img captions + links + external heros + OG img w/ fallback

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.2.5-alpha.5",
+	title: "eleventeen v9.2.6-alpha.5",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",
@@ -8,8 +8,9 @@ let data = {
 		email: "juanita@example.com",
 		url: "https://example.org",
 	},
+	siteimage: "https://o.famebot.com/file/famebot/eleventeen.png",
 	mono: false,
-	eleventeen: "v9.2.5-alpha.5",
+	eleventeen: "v9.2.6-alpha.5",
 };
 
 export default data;

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -6,7 +6,8 @@
 		<meta name="theme-color" content="white">
 		<title>{{ title or metadata.title }}</title>
 		<meta name="description" content="{{ description or metadata.description }}">
-
+		<meta property="og:image" content="{% shareimg hero or metadata.siteimage %}" />
+		{# {{ hero or metadata.siteimage }} #}
 		{#- Atom and JSON feeds included by default #}
 		<link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}">
 		<link rel="alternate" href="/feed/feed.json" type="application/json" title="{{ metadata.title }}">

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -6,9 +6,28 @@ layout: layouts/base.njk
 {% include "node_modules/prismjs/themes/prism-okaidia.css" %}
 {% include "public/css/prism-diff.css" %}
 {%- endcss %}
+<figure>
 {%- if hero and heroalt %}
-{% image hero, heroalt %}
+
+	{%- if herolink %}
+		<a href={{ herolink }}>
+	{%- endif %}
+
+	{% image hero, heroalt %}
+
+	{%- if herolink %}
+		</a>
+	{%- endif %}
+
+	{%- if herocaption %}
+		<figcaption>
+			{%- if herolink %}<a href={{ herolink }}>{%- endif %}
+			{{ herocaption }}
+			{%- if herolink %}</a>{%- endif %}
+		</figcaption>
+	{%- endif %}
 {%- endif %}
+</figure>
 <h1>{{ title }}</h1>
 
 <ul class="post-metadata">

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -5,7 +5,13 @@
 {% for post in postslist | reverse %}
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
 		{%- if post.data.hero and post.data.heroalt %}
-		<figure class="postlist-img"><a href="{{ post.url }}" class="postlist-thumb">{% image ['./', post.url, post.data.hero] | join, post.data.heroalt, [488] %}</a></figure>
+		<figure class="postlist-img"><a href="{{ post.url }}" class="postlist-thumb">
+			{%- if post.data.hero | fullPostImgUrl %}
+				{% image post.data.hero, post.data.heroalt, [488] %}
+			{%- else %}
+				{% image ['./', post.url, post.data.hero] | join, post.data.heroalt, [488] %}
+			{%- endif %}
+		</a></figure>
 		{%- endif %}
 		<div class="postlist-text">
 			<a href="{{ post.url }}" class="postlist-link ellipsize">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,10 +13,16 @@ Eleventy Base Blog is:
 
 > A starter repository showing how to build a blog with the [Eleventy](https://www.11ty.dev/) site generator (using the [v2.0 release](https://www.11ty.dev/blog/eleventy-v2/)).
 
-In addition to Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode™](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color
-names.” We posit a third color scheme preference in addition to light and dark “modes,” rainbow.
+## Rainbow Mode™
 
-Here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer, so [v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5), adds a `mono` option to [`_data/metadata.js`](https://github.com/rdela/eleventeen/blob/trunk/_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that will disable Rainbow Mode if you set it to `true`. `mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false`, plus it might make the current  {% raw %}`{%- if not metadata.mono %}`{% endraw %} template logic in [`_includes/layouts/base.njk`](https://github.com/rdela/eleventeen/blob/trunk/_includes/layouts/base.njk) a little more resilient.
+In addition to Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color
+names.”
+
+### prefers-color-scheme: rainbow
+
+We posit a third color scheme preference in addition to light and dark “modes,” rainbow. And here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer, so [v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5), adds a `mono` option to [`_data/metadata.js`](https://github.com/rdela/eleventeen/blob/trunk/_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that will disable Rainbow Mode if you set it to `true`. 
+
+`mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false`, plus it might make the current  {% raw %}`{%- if not metadata.mono %}`{% endraw %} template logic in [`_includes/layouts/base.njk`](https://github.com/rdela/eleventeen/blob/trunk/_includes/layouts/base.njk) a little more resilient.
 
 You can see mono enabled at [mono.eleventeen.blog](https://mono.eleventeen.blog). Try toggling light and dark mode using devtools, there are links to how at the bottom to [chromagen.io](https://chromagen.io/). The rainbow eleventeen demo still lives at [eleventeen.blog](https://eleventeen.blog) <span role="img" aria-label="">🌈📓</span>
 

--- a/content/archive/fourthpost/fourthpost.md
+++ b/content/archive/fourthpost/fourthpost.md
@@ -4,6 +4,8 @@ description: This is a post on My Blog about touchpoints and circling wagons.
 date: 2018-09-30
 hero: elle-balloon-r1-t1-c4.png
 heroalt: Elle the possum floats, suspended from a red balloon, seen from afar.
+herocaption: Illustration of Eleventy mascot Elle the possum by Ricky de Laveaga
+herolink: https://www.11ty.dev/blog/logo-homage/
 tags: second tag
 ---
 Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity and empowerment.

--- a/content/archive/secondpost/secondpost.md
+++ b/content/archive/secondpost/secondpost.md
@@ -4,6 +4,8 @@ description: Republishing my guest post on Ellipsize about leveraging agile fram
 date: 2018-07-04
 hero: elle-balloon-r1-t1-c2.png
 heroalt: Close-up of Elle the possum, suspended from a red balloon.
+herocaption: Illustration of Eleventy mascot Elle the possum by Ricky de Laveaga
+herolink: https://www.11ty.dev/blog/logo-homage/
 tags:
   - number 2
 ---

--- a/content/archive/thirdpost.md
+++ b/content/archive/thirdpost.md
@@ -2,11 +2,15 @@
 title: This is my third post.
 description: This is a post on My Blog about win-win survival strategies.
 date: 2018-08-24
+hero: https://raw.githubusercontent.com/11ty/11ty-website/a394cc007a0fb752fc65abef26b238c64c4134af/src/blog/eight-million.jpg
+heroalt: Zach pointing to the new balloons in his office that say 8 Million
+herocaption: Eight Million Eleventy npm Downloads!
+herolink: https://www.11ty.dev/blog/eight-million/
 tags:
   - second tag
   - posts with two tags
 ---
-Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity and empowerment.
+External hero/OG images? You betcha. (Talkin bout [Open Graph](https://ogp.me/) images, not [Original Gangster](https://www.33rdsquare.com/what-is-og-in-slang-mean/) images, nor [Ocean Grown](https://apotforpot.com/blogs/learn/og/) images, unfortunately.) Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity and empowerment.
 
 ## Code
 

--- a/eleventy.config.images.js
+++ b/eleventy.config.images.js
@@ -50,4 +50,40 @@ export default function (eleventyConfig) {
 			return eleventyImage.generateHTML(metadata, imageAttributes);
 		}
 	);
+
+	eleventyConfig.addAsyncShortcode(
+		"shareimg",
+		async function shareImageShortcode(src) {
+			let input;
+			if (isFullUrl(src)) {
+				input = src;
+			} else {
+				input = relativeToInputPath(this.page.inputPath, src);
+			}
+
+			let metadata = await eleventyImage(input, {
+				widths: [1280],
+				formats: ["jpeg", "png"],
+				outputDir: path.join(eleventyConfig.dir.output, "img"),
+			});
+
+			let data;
+			let ext = input.slice(-3);
+			if (ext === "jpg") {
+				data = metadata.jpeg[metadata.jpeg.length - 1];
+			} else {
+				data = metadata.png[metadata.png.length - 1];
+			}
+
+			return data.url;
+		}
+	);
+
+	eleventyConfig.addFilter("fullPostImgUrl", (src) => {
+		if (isFullUrl(src)) {
+			return true;
+		} else {
+			return false;
+		}
+	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.5-alpha.5",
+	"version": "9.2.6-alpha.5",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -163,6 +163,12 @@ figure {
 	margin: 0;
 }
 
+figcaption {
+	text-align: center;
+	font-size: 1rem;
+	margin-top: 0.25rem;
+}
+
 /* header {
 	border-bottom: 1px dashed #e0e0e0;
 } 


### PR DESCRIPTION
- NEW `herocaption` and `herolink` fields available in frontmatter

- metadata.js
  + add `siteimage` default OG image
  + bump ver to v9.2.6-alpha.5

- eleventy.config.images.js
  + new shareimg shortcode, outputs jpg and png at 1280 W
  + fullPostImgUrl filter

- base.njk
  + use new shareimg shortcode w/ siteimage fallback `{% shareimg hero or metadata.siteimage %}`

- style figcaption in index.css

- expand and edit about/index.md