### PR TITLE
theme-color activation, typographic + docs revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,35 @@
 
 [![](https://o.famebot.com/file/famebot/eleventeen.png)](https://eleventeen.blog)
 
+Eleventeen is an evolving variation of [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), an [Eleventy](https://www.11ty.dev) blog starter. The name is an homage to the [Daisy Chainsaw album](https://en.wikipedia.org/wiki/Eleventeen_(album)) <span role="img" aria-label="">👩🏻‍🎤🎶</span>
+
 ## WARNING: Here Be Canaries <span role="img" aria-label="">🐥</span>
 
-This starter has advanced ahead of its upstream source, [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), to boldy embrace [Eleventy v3](https://www.11ty.dev/blog/canary-eleventy-v3/) in [PR #8](https://github.com/rdela/eleventeen/pull/8) / [v9.0.0-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.0.0-alpha.5).
+Eleventeen boldly embraced [Eleventy v3](https://www.11ty.dev/blog/canary-eleventy-v3/) ahead of its upstream source in [PR #8](https://github.com/rdela/eleventeen/pull/8) / [v9.0.0-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.0.0-alpha.5), while Eleventy Base Blog remains on the stable [v2 release](https://www.11ty.dev/blog/eleventy-v2/)) as of 28 April 2024.
 
-Eleventy Base Blog is:
+## Rainbow Mode™
 
-> A starter repository showing how to build a blog with the [Eleventy](https://www.11ty.dev/) site generator (using the [v2.0 release](https://www.11ty.dev/blog/eleventy-v2/)).
+In addition to Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode™](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color names.”
 
-In addition to Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode™](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color
-names.” We posit a third color scheme preference in addition to light and dark “modes,” rainbow.
+### prefers-color-scheme: rainbow
 
-Here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer, so [v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5), adds a `mono` option to [`_data/metadata.js`](_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that will disable Rainbow Mode if you set it to `true`. `mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false` and might make the current `{%- if not metadata.mono %}` template logic in [`_includes/layouts/base.njk`](_includes/layouts/base.njk) a little more resilient.
+We posit a third color scheme preference in addition to light and dark “modes,” rainbow. And here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer.
 
-You can see mono enabled at [mono.eleventeen.blog](https://mono.eleventeen.blog). Try toggling light and dark mode using devtools, there are links to how at the bottom to [chromagen.io](https://chromagen.io/). The rainbow eleventeen demo still lives at [eleventeen.blog](https://eleventeen.blog) <span role="img" aria-label="">🌈📓</span>
+## Mono Mode <span role="img" aria-label="">📓🏁</span>
 
-<figure role="img" aria-label="">fig. 1<br />
-🎈📓 ➕ 🎨💥 🟰 🌈💥</figure><br />
+[v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5) added a `mono` option to [`_data/metadata.js`](_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that disables Rainbow Mode if you set it to `true`.
+
+`mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false`. Plus it might make the current `{%- if not metadata.mono %}` template logic in [`_includes/layouts/base.njk`](_includes/layouts/base.njk) a little more resilient.
+
+### Show Me the Mono
+
+You can see mono enabled at [mono.eleventeen.blog](https://mono.eleventeen.blog)
+
+Try toggling light and dark mode using devtools, there are links to how at the bottom to [chromagen.io](https://chromagen.io/)
+
+The rainbow eleventeen demo still lives (happily ever after) at [eleventeen.blog](https://eleventeen.blog)
+
+## Other Additions to and Divergences from Eleventy Base Blog
 
 Rejoicing and rainbows aside, eleventeen also adds post images in [PR #10](https://github.com/rdela/eleventeen/pull/10) / [v9.2.1-alpha.5 ](https://github.com/rdela/eleventeen/releases/tag/v9.2.1-alpha.5), refines them further in 🎈[PR #11](https://github.com/rdela/eleventeen/pull/10) / [v9.2.2-alpha.5 ](https://github.com/rdela/eleventeen/releases/tag/v9.2.2-alpha.5), and makes some more subtle adjustments to Eleventy Base Blog. There are various changes in `public/css/index.css`, and in `_includes/postslist.njk`:
 
@@ -32,7 +44,7 @@ becomes:
 <ul reversed class="postlist">
 ```
 
-The eleventeen name is an homage to the [Daisy Chainsaw album](https://en.wikipedia.org/wiki/Eleventeen_(album)) <span role="img" aria-label="">👩🏻‍🎤🎶</span>
+The example About page [`content/about/index.md`](content/about/index.md) tells the story as well.
 
 Please remember to star [eleventeen on GitHub](https://github.com/rdela/eleventeen) <span role="img" aria-label="">⭐️🐙</span>
 

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.2.8-alpha.9",
+	title: "eleventeen v9.2.9-alpha.9",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",
@@ -10,7 +10,7 @@ let data = {
 	},
 	siteimage: "https://o.famebot.com/file/famebot/eleventeen.png",
 	mono: false,
-	eleventeen: "9.2.8-alpha.9",
+	eleventeen: "9.2.9-alpha.9",
 };
 
 export default data;

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -65,7 +65,7 @@
 
 			<footer>
 				{%- if not metadata.mono %}
-					{#- Rainbow Mode enabled, show 🌈 Rainbow button #}
+					{#- Rainbow Mode enabled, show 🌈 Rainbow button and readout #}
 					<div id="rainbutton"></div>
 					<aside id="chromagen"></aside>
 				{% endif %}
@@ -90,13 +90,16 @@ function activateColorScheme() {
 		document.querySelector('meta[name="theme-color"]').setAttribute('content', huedark);
 	}
 }
+{# activate initial theme-color in mono mode #}
+activateColorScheme();
+{# respond to prefers-color-scheme changes #}
 const darkPreference = window.matchMedia("(prefers-color-scheme: dark)");
 const lightPreference = window.matchMedia("(prefers-color-scheme: light)");
 darkPreference.addEventListener("change", e => e.matches && activateColorScheme());
 lightPreference.addEventListener("change", e => e.matches && activateColorScheme());
 			{% endjs %}
 			
-			{# rainbow mode magic #}
+			{# rainbow mode code lode #}
 			{%- if not metadata.mono %}
 			{% js %}
 				{% include "node_modules/@famebot/chromagen/dist/chromagen.umd.js" %}
@@ -104,7 +107,6 @@ lightPreference.addEventListener("change", e => e.matches && activateColorScheme
 			{% js %}
 const rainbow = () => {
 var colorScheme = chromagen();
-
 {#- https://davidwalsh.name/css-variables-javascript #}
 const docstyle = document.documentElement.style;
 huedark = `hsl(${colorScheme.hue}, ${colorScheme.saturation}, ${colorScheme.darkness})`;
@@ -121,8 +123,14 @@ docstyle.setProperty('--primarydark', `hsl(${colorScheme.complement}, ${colorSch
 docstyle.setProperty('--primarydarker', `hsl(${colorScheme.complement}, ${colorScheme.saturation}, ${colorScheme.darker})`);
 docstyle.setProperty('--text-color-dark', `hsl(${colorScheme.hue}, ${colorScheme.saturation}, ${colorScheme.lighter})`);
 docstyle.setProperty('--text-color-light', `hsl(${colorScheme.hue}, ${colorScheme.saturation}, ${colorScheme.darker})`);
-
+{# 
+	activate theme-color so theme-color updates even if page already loaded, 
+	for example when Rainbow Me button is clicked.
+#}
+activateColorScheme();
+{# connect Rainbow Me button #}
 document.querySelector('#rainbutton').innerHTML = `<button title="wish upon a star" onclick="rainbow()">🌈 Rainbow Me</button>`;
+{# update readout #}
 document.querySelector('#chromagen').innerHTML = `<details>
 	<summary><span role="img" aria-label="palette">🎨</span>
 		<span title="hue"> H&nbsp;${colorScheme.hue} </span> 
@@ -143,12 +151,7 @@ document.querySelector('#chromagen').innerHTML = `<details>
 rainbow();
 			{% endjs %}
 			{% endif %}
-			{# end rainbow mode magic #}
-
-			{# activate initial theme-color in both mono and rainbow modes #}
-			{% js %}
-activateColorScheme();
-			{% endjs %}
+			{# end rainbow mode code lode #}
 
 			{#
 				getBundleFileUrl Writes the bundle content to a content-hashed file location in your 

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,6 +1,3 @@
-{# if using ol instead of ul and also fancy try:
-	style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}"
-#}
 <ul reversed class="postlist">
 {% for post in postslist | reverse %}
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -5,9 +5,9 @@ eleventyNavigation:
   order: 3
 ---
 
-# About
+# About Eleventeen <span role="img" aria-label="">🌈📓</span>
 
-Eleventeen is a work in progress variation of [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), an [Eleventy](https://www.11ty.dev) blog starter. The name is an homage to the [Daisy Chainsaw album](https://en.wikipedia.org/wiki/Eleventeen_(album)) <span role="img" aria-label="">👩🏻‍🎤🎶</span>
+Eleventeen is an evolving variation of [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), an [Eleventy](https://www.11ty.dev) blog starter. The name is an homage to the [Daisy Chainsaw album](https://en.wikipedia.org/wiki/Eleventeen_(album)) <span role="img" aria-label="">👩🏻‍🎤🎶</span>
 
 Eleventy Base Blog is:
 
@@ -15,15 +15,26 @@ Eleventy Base Blog is:
 
 ## Rainbow Mode™
 
-In addition to Base Blog’s killer features and Eleventy 3’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color
-names.”
+In addition to Base Blog’s killer features and [Eleventy v3](https://www.11ty.dev/blog/canary-eleventy-v3/)’s bundler-free [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support, eleventeen sports a novel new visual experience we call [Rainbow Mode](https://github.com/rdela/eleventeen/pull/1), powered by [Chromagen](https://github.com/famebot/chromagen), the color scheme generator we publish under the [Famebot](https://github.com/famebot) organization. Our homegrown Rainbow Mode is wholly distinct from and not to be confused with Emacs [rainbow-mode](https://elpa.gnu.org/packages/rainbow-mode.html), which “sets background color to strings that match color&nbsp;names.”
 
 ### prefers-color-scheme: rainbow
 
-We posit a third color scheme preference in addition to light and dark “modes,” rainbow. And here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer, so [v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5), adds a `mono` option to [`_data/metadata.js`](https://github.com/rdela/eleventeen/blob/trunk/_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that will disable Rainbow Mode if you set it to `true`. 
+We posit a third color scheme preference in addition to light and dark “modes,” rainbow. And here in the world of eleventeen, rainbow is the default. But we acknowledge not all sites are a match for Rainbow Mode, and still want those sites to enjoy the rest of what eleventeen has to offer.
 
-`mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false`, plus it might make the current  {% raw %}`{%- if not metadata.mono %}`{% endraw %} template logic in [`_includes/layouts/base.njk`](https://github.com/rdela/eleventeen/blob/trunk/_includes/layouts/base.njk) a little more resilient.
+## Mono Mode <span role="img" aria-label="">📓🏁</span>
 
-You can see mono enabled at [mono.eleventeen.blog](https://mono.eleventeen.blog). Try toggling light and dark mode using devtools, there are links to how at the bottom to [chromagen.io](https://chromagen.io/). The rainbow eleventeen demo still lives at [eleventeen.blog](https://eleventeen.blog) <span role="img" aria-label="">🌈📓</span>
+[v9.2.3-alpha.5](https://github.com/rdela/eleventeen/releases/tag/v9.2.3-alpha.5) added a `mono` option to [`_data/metadata.js`](https://github.com/rdela/eleventeen/blob/trunk/_data/metadata.js) in [PR #13](https://github.com/rdela/eleventeen/pull/13) that disables Rainbow Mode if you set it to `true`.
+
+`mono` is `false` by default, on purpose, because it beats making people set an option called `rainbow` to `false`. Plus it might make the current  {% raw %}`{%- if not metadata.mono %}`{% endraw %} template logic in [`_includes/layouts/base.njk`](https://github.com/rdela/eleventeen/blob/trunk/_includes/layouts/base.njk) a little more resilient.
+
+### Show Me the Mono
+
+You can see Mono Mode enabled at [mono.eleventeen.blog](https://mono.eleventeen.blog)
+
+Try toggling light and dark mode using devtools, there are links to how at the bottom to [chromagen.io](https://chromagen.io/)
+
+The rainbow eleventeen demo still lives (happily ever after) at [eleventeen.blog](https://eleventeen.blog)
+
+## Star Power <span role="img" aria-label="">⭐️⚡️</span>
 
 Please remember to star [eleventeen on GitHub](https://github.com/rdela/eleventeen) <span role="img" aria-label="">⭐️🐙</span>

--- a/content/archive/secondpost/secondpost.md
+++ b/content/archive/secondpost/secondpost.md
@@ -14,8 +14,13 @@ Edit posts in the github app like wheeeeeee agile frameworks to provide a robust
 
 ## Section Header
 
-<a href="/archive/firstpost/">First post</a>
-<a href="/archive/thirdpost/">Third post</a>
+- <a href="/archive/firstpost/">First post</a>
+  + [Section Header](/archive/firstpost/#section-header)
+- <a href="/archive/thirdpost/">Third post</a>
+  + [Code](/archive/thirdpost/#code)
+    * [Styled (with Syntax)](/archive/thirdpost/#styled-with-syntax)
+    * [Unstyled](/archive/thirdpost/#unstyled)
+  + [Section Header](/archive/thirdpost/#section-header)
 
 Bring to the table win-win survival strategies to ensure proactive domination. At the end of the day, going forward, a new normal that has evolved from generation X is on the runway heading towards a streamlined cloud solution. User generated content in real-time will have multiple touchpoints for offshoring.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.8-alpha.9",
+	"version": "9.2.9-alpha.9",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -100,6 +100,17 @@ p {
 	line-height: 1.5;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+	margin-block-end: 1.5rem;
+	margin-block-start: 1.5rem;
+}
+
 li {
 	line-height: 1.5;
 }
@@ -148,18 +159,6 @@ button:active,
 	border-color: var(--text-color-link-visited);
 }
 
-main {
-	font-size: var(--article-font-size);
-}
-main :first-child {
-	margin-top: 0;
-}
-
-main img {
-	height: auto;
-	max-width: 100%;
-}
-
 figure {
 	margin: 0;
 }
@@ -169,15 +168,6 @@ figcaption {
 	font-size: 1rem;
 	margin-top: 0.25rem;
 }
-
-/* header {
-	border-bottom: 1px dashed #e0e0e0;
-} 
-header:after {
-	content: "";
-	display: table;
-	clear: both;
-} */
 
 .links-nextprev {
 	list-style: none;
@@ -213,14 +203,35 @@ pre:not([class*="language-"]) {
 	word-break: normal;
 }
 code {
-	word-break: break-all;
+	word-break: break-word;
+}
+
+main {
+	font-size: var(--article-font-size);
+	padding: 0 1rem;
+}
+main :first-child {
+	margin-top: 0;
+}
+
+main img {
+	height: auto;
+	max-width: 100%;
 }
 
 footer,
-header,
-main {
+header {
 	padding: 1rem;
 }
+
+/* header {
+	border-bottom: 1px dashed #e0e0e0;
+} 
+header:after {
+	content: "";
+	display: table;
+	clear: both;
+} */
 
 footer {
 	display: flex;
@@ -344,8 +355,6 @@ header {
 .postlist-text {
 	display: flex;
 	flex-direction: column;
-	padding-bottom: 0.65625em;
-	padding-top: 0.4375em;
 }
 .postlist-text a {
 	line-height: 1.25;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -106,14 +106,46 @@ p {
 	margin-block-start: 1.5rem;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	line-height: 1.25;
+}
+
+h1 {
+	font-size: 2em;
+}
+
+h2 {
+	font-size: 1.5em;
+}
+
+h3 {
+	font-size: 1.125em;
+}
+
+h4 {
+	font-size: 1.0625em;
+}
+
+h5 {
+	font-size: 0.9375em;
+	text-transform: uppercase;
+}
+
+h6 {
+	font-size: 0.875em;
+	text-transform: uppercase;
+}
+
 p:last-child {
 	margin-block-end: 0;
 }
 
-p {
-	line-height: 1.5;
-}
-
+p,
 li {
 	line-height: 1.5;
 }
@@ -424,7 +456,7 @@ a.header-anchor:hover {
 
 a.header-anchor:focus,
 :hover > a.header-anchor {
-	color: #aaa;
+	color: var(--text-color-link-highlight);
 }
 
 h2 + .header-anchor {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -15,14 +15,14 @@
 	--background-color-dark: #000;
 	--background-color: var(--background-color-light);
 
-	--active-light: hsl(172, 94%, 20%); /* #17050f */
-	--active-dark: hsl(172, 94%, 65%); /* #a6a6f8 */
-	--complement: hsl(38, 94%, 65%); /* #1493fb */
-	--complementdarker: hsl(38, 94%, 9%); /* #5f2b48 */
-	--primary: hsl(351, 94%, 65%); /* #6969f7 */
-	--primarydarker: hsl(351, 94%, 9%); /* #082840 */
-	--text-color-dark: hsl(172, 94%, 83%); /* #dad8d8 */
-	--text-color-light: hsl(172, 94%, 9%); /* #282828 */
+	--active-light: hwb(172 1% 61%);
+	--active-dark: hsl(172, 94%, 65%);
+	--complement: hsl(38, 94%, 65%);
+	--complementdarker: hsl(38, 94%, 9%);
+	--primary: hsl(351, 94%, 65%);
+	--primarydarker: hsl(351, 94%, 9%);
+	--text-color-dark: hsl(172, 94%, 83%);
+	--text-color-light: hsl(172, 94%, 9%);
 
 	--text-color: var(--text-color-light);
 	--text-color-link: var(--text-color-light);
@@ -68,9 +68,11 @@ body {
 	color: var(--text-color);
 	background-color: var(--background-color);
 }
+
 html {
 	overflow-y: scroll;
 }
+
 body {
 	min-height: 100vh;
 	min-height: 100dvh;
@@ -93,13 +95,6 @@ body {
 	width: 1px;
 }
 
-p:last-child {
-	margin-bottom: 0;
-}
-p {
-	line-height: 1.5;
-}
-
 h1,
 h2,
 h3,
@@ -111,6 +106,14 @@ p {
 	margin-block-start: 1.5rem;
 }
 
+p:last-child {
+	margin-block-end: 0;
+}
+
+p {
+	line-height: 1.5;
+}
+
 li {
 	line-height: 1.5;
 }
@@ -118,13 +121,16 @@ li {
 a {
 	color: var(--text-color-link);
 }
+
 a:visited {
 	color: var(--text-color-link-visited);
 }
+
 a:focus,
 a:hover {
 	color: var(--text-color-link-highlight);
 }
+
 a:active {
 	color: var(--text-color-link-active);
 }
@@ -132,6 +138,7 @@ a:active {
 .button {
 	text-decoration: none;
 }
+
 button,
 .button {
 	background-color: transparent;
@@ -141,6 +148,7 @@ button,
 	font-size: 1.5em;
 	padding: 0.25em 0.5em;
 }
+
 button:focus,
 button:hover,
 .button:focus, 
@@ -149,12 +157,14 @@ button:hover,
 	border-color: var(--text-color-link-highlight);
 	color: var(--button-text-highlight);
 }
+
 button:active, 
 .button:active {
 	background-color: var(--primary);
 	border-color: var(--button-border-highlight);
 	color: var(--button-text-highlight);
 }
+
 .button:visited {
 	border-color: var(--text-color-link-visited);
 }
@@ -166,27 +176,28 @@ figure {
 figcaption {
 	text-align: center;
 	font-size: 1rem;
-	margin-top: 0.25rem;
+	margin-block-start: 0.25rem;
 }
 
 .links-nextprev {
 	list-style: none;
-	/* border-top: 1px dashed #e0e0e0; */
 	padding: 1em 0;
 }
 
 table {
 	margin: 1em 0;
 }
+
 table td,
 table th {
-	padding-right: 1em;
+	padding-inline-end: 1em;
 }
 
 pre,
 code {
 	font-family: var(--font-family-monospace);
 }
+
 pre:not([class*="language-"]) {
 	margin: 0.5em 0;
 	line-height: 1.375; /* 22px /16 */
@@ -202,6 +213,7 @@ pre:not([class*="language-"]) {
 	word-spacing: normal;
 	word-break: normal;
 }
+
 code {
 	word-break: break-word;
 }
@@ -210,8 +222,9 @@ main {
 	font-size: var(--article-font-size);
 	padding: 0 1rem;
 }
+
 main :first-child {
-	margin-top: 0;
+	margin-block-start: 0;
 }
 
 main img {
@@ -223,15 +236,6 @@ footer,
 header {
 	padding: 1rem;
 }
-
-/* header {
-	border-bottom: 1px dashed #e0e0e0;
-} 
-header:after {
-	content: "";
-	display: table;
-	clear: both;
-} */
 
 footer {
 	display: flex;
@@ -256,6 +260,7 @@ footer {
 }
 
 /* Header */
+
 header {
 	align-items: center;
 	display: flex;
@@ -263,11 +268,13 @@ header {
 	gap: 1em 0.5em;
 	justify-content: space-between;
 }
+
 .home-link {
 	font-size: 1em; /* 16px /16 */
 	font-weight: 700;
-	margin-right: 2em;
+	margin-inline-end: 2em;
 }
+
 .home-link:link:not(:hover) {
 	text-decoration: none;
 }
@@ -279,86 +286,86 @@ header {
 	margin: 0;
 	list-style: none;
 }
+
 .nav-item {
 	display: inline-block;
-	margin-right: 1em;
+	margin-inline-end: 1em;
 }
+
 .nav-item a:not(:hover) {
 	text-decoration: none;
 }
+
 .nav a[aria-current="page"] {
 	text-decoration: underline;
 }
 
 /* Posts list */
+
 .postlist {
 	list-style: none;
 	padding: 0;
-	/* if using ol in _includes/postslist.njk */
-	/* padding-left: 1.5rem; */
 }
+
 .postlist-item {
 	display: flex;
 	align-items: center;
-	margin-bottom: 1em;
+	margin-block-end: 1em;
 }
+
 @media screen and (max-width: 320px) {
 	.postlist-item {
-		/* moved from prev rule */
 		flex-wrap: wrap;
 	}
 }
-/* if using ol in _includes/postslist.njk */
-/* counter-increment: start-from -1;
-}
-/* .postlist-item:before {
-	display: inline-block;
-	pointer-events: none;
-	content: "" counter(start-from, decimal-leading-zero) ". ";
-	line-height: 100%;
-	text-align: right;
-	margin-left: -1.5rem;
-} 
-.postlist-item:before, 
-*/
+
 .postlist-date {
 	font-size: 0.8125em; /* 13px /16 */
 	color: var(--text-color);
 }
+
 .postlist-date {
 	word-spacing: -0.5px;
 }
+
 .postlist-link {
 	font-size: 1.1875em; /* 19px /16 */
 	font-weight: 700;
-	flex-basis: calc(100% - 1.5rem); /* see postlist-item:before margin-left above */
+	flex-basis: 100%;
 	text-underline-position: from-font;
 	text-underline-offset: 0;
 	text-decoration-thickness: 1px;
 }
+
 .postlist-item-active .postlist-link {
 	font-weight: bold;
 }
+
 .postlist-thumb,
 .postlist-img img {
 	display: block;
 }
+
 .postlist-img img {
 	height: 128px;
 	width: 128px;
 	object-fit: cover;
 }
+
 .postlist-img {
-	margin-right: 1em;
+	margin-inline-end: 1em;
 	min-width: 128px;
 }
+
 .postlist-text {
 	display: flex;
 	flex-direction: column;
 }
+
 .postlist-text a {
 	line-height: 1.25;
 }
+
 .ellipsize {
 	overflow: hidden; /* keeps the element from overflowing its parent */
 	display: -webkit-box;
@@ -378,6 +385,7 @@ header {
 	text-transform: capitalize;
 	font-style: italic;
 }
+
 .postlist-item > .post-tag {
 	align-self: center;
 }
@@ -391,8 +399,9 @@ header {
 	padding: 0;
 	margin: 0;
 }
+
 .post-metadata time {
-	margin-right: 1em;
+	margin-inline-end: 1em;
 }
 
 /* Direct Links / Markdown Headers */
@@ -400,16 +409,19 @@ header {
 	text-decoration: none;
 	font-style: normal;
 	font-size: 1em;
-	margin-left: 0.1em;
+	margin-inline-start: 0.1em;
 }
+
 a.header-anchor,
 a.header-anchor:visited {
 	color: transparent;
 }
+
 a.header-anchor:focus,
 a.header-anchor:hover {
 	text-decoration: underline;
 }
+
 a.header-anchor:focus,
 :hover > a.header-anchor {
 	color: #aaa;


### PR DESCRIPTION
* v9.2.9-alpha.9

* feat: heading line-height and minimal font scale header-anchor focus color

* feat: refactor index.css, embrace the vertical space

  - carriage returns are free
  - use block-end/start and inline-end/start for margin + padding 
    where sensible
  - remove postslist ol cruft and comment cruft

* feat: typographic styling and docs revamp

  - normalize heading and paragraph margins at 1.5rem for now
  - reduce padding between main and header/footer
  - eliminate .postlist-text vertical padding
  - set code elements word-break to break-word instead of break-all
  - make html link test in secondpost.md also exercise nested unordered lists
    and mixed markdown and html syntax
  - break up walls of text in readme and about page
  - work in progress => evolving variation

* fix: correct logic in theme-color activation sequence

  repairs regression in v9.2.8-alpha.9 that broke theme-color updates when
  Rainbow Me button activated in rainbow mode (default).

  to recap, v9.2.8 fixed the issue where theme-color did not update in 
  mono mode when prefers-color-scheme was set to dark, but in reshuffling 
  function calls inadvertently created the bug described above and fixed here.