### PR TITLE
revert vs code color picker hsl to hwb swap

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.2.9-alpha.9",
+	title: "eleventeen v9.2.10-alpha.9",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",
@@ -10,7 +10,7 @@ let data = {
 	},
 	siteimage: "https://o.famebot.com/file/famebot/eleventeen.png",
 	mono: false,
-	eleventeen: "9.2.9-alpha.9",
+	eleventeen: "9.2.10-alpha.9",
 };
 
 export default data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.9-alpha.9",
+	"version": "9.2.10-alpha.9",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -15,7 +15,7 @@
 	--background-color-dark: #000;
 	--background-color: var(--background-color-light);
 
-	--active-light: hwb(172 1% 61%);
+	--active-light: hsl(172, 94%, 20%);
 	--active-dark: hsl(172, 94%, 65%);
 	--complement: hsl(38, 94%, 65%);
 	--complementdarker: hsl(38, 94%, 9%);


### PR DESCRIPTION
fix: revert vs code color picker hsl to hwb swap

v9.2.10-alpha.9