### PR TITLE
pre white-space to pre-wrap, rename + add build to browser-sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ You can run [debug mode](https://www.11ty.dev/docs/debugging/) to see all the in
 
 ## Demos
 
-- eleventeen on Netlify: <https://eleventeen.blog> or <https://eleventeen.netlify.app>
+- eleventeen on Netlify, Rainbow Mode (default): <https://eleventeen.blog>
+  or <https://eleventeen.netlify.app>
+- eleventeen on Netlify, Mono Mode: <https://mono.eleventeen.blog>
 - [eleventy-base-blog on Netlify](https://eleventy-base-blog.netlify.app)
 - [eleventy-base-blog on GitHub Pages](https://11ty.github.io/eleventy-base-blog/)
 - [Remix eleventy-base-blog on Glitch](https://glitch.com/~11ty-eleventy-base-blog)

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,5 +1,5 @@
 let data = {
-	title: "eleventeen v9.2.11-alpha.9",
+	title: "eleventeen v9.2.12-alpha.9",
 	url: "https://eleventeen.blog",
 	language: "en",
 	description: "Rainbow Eleventy blog",
@@ -10,7 +10,7 @@ let data = {
 	},
 	siteimage: "https://o.famebot.com/file/famebot/eleventeen.png",
 	mono: false,
-	eleventeen: "9.2.11-alpha.9",
+	eleventeen: "9.2.12-alpha.9",
 };
 
 export default data;

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   order: 3
 ---
 
-# About Eleventeen <span role="img" aria-label="">🌈📓</span>
+# About eleventeen <span role="img" aria-label="">🌈📓</span>
 
 Eleventeen is an evolving variation of [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog), an [Eleventy](https://www.11ty.dev) blog starter. The name is an homage to the [Daisy Chainsaw album](https://en.wikipedia.org/wiki/Eleventeen_(album)) <span role="img" aria-label="">👩🏻‍🎤🎶</span>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.11-alpha.9",
+	"version": "9.2.12-alpha.9",
 	"description": "A starter repository for a blog web site using the Eleventy site generator.",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
 		"build": "eleventy",
 		"build-ghpages": "eleventy --pathprefix=/eleventeen/",
 		"d": "eleventy --serve --quiet",
-		"noisy": "eleventy --serve",
-		"serve": "npx browser-sync '_site' --port 8080 --no-ghost-mode --no-notify --no-ui",
 		"start": "eleventy --serve --quiet",
+		"noisy": "eleventy --serve",
+		"bs": "eleventy && npx browser-sync '_site' --port 8080 --no-ghost-mode --no-notify --no-ui",
 		"debug": "DEBUG=Eleventy* eleventy",
 		"debugstart": "DEBUG=Eleventy* eleventy --serve --quiet",
 		"benchmark": "DEBUG=Eleventy:Benchmark* eleventy"

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -241,7 +241,7 @@ pre:not([class*="language-"]) {
 	hyphens: none;
 	direction: ltr;
 	text-align: left;
-	white-space: pre;
+	white-space: pre-wrap;
 	word-spacing: normal;
 	word-break: normal;
 }


### PR DESCRIPTION
v9.2.12-alpha.9

fix: pre white-space to pre-wrap, rename + fortify browser-sync script

- Unstyled section in third post was breaking layout on mobile.
  Try toggling `pre-wrap` back to `pre` to see the issue: 
  https://eleventeen.blog/archive/thirdpost/#unstyled
  or see it in Base Blog on small enough screens: 
  https://eleventy-base-blog.netlify.app/blog/thirdpost/#unstyled
  Note text is larger in eleventeen.

- `pre-wrap` Sequences of white space are preserved. Lines are broken at 
  newline characters, at `<br>`, and as necessary to fill line boxes.
  https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

- rename browser-sync script from 9.2.11 / #23: 
  https://github.com/rdela/eleventeen/releases/tag/v9.2.11-alpha.9
  https://github.com/rdela/eleventeen/pull/23/files
  from `serve` to `bs`
  this disambiguates it from Eleventy's built in serve / dev server
  also might as well build first so now begins w/ `eleventy &&`