### PR TITLE
eleventy 3.0.0-alpha.17, IdAttributePlugin, eleventeen.png

### DIFF
--- a/content/archive/thirdpost.md
+++ b/content/archive/thirdpost.md
@@ -2,10 +2,10 @@
 title: This is my third post.
 description: This is a post on My Blog about win-win survival strategies.
 date: 2018-08-24
-hero: https://raw.githubusercontent.com/11ty/11ty-website/a394cc007a0fb752fc65abef26b238c64c4134af/src/blog/eight-million.jpg
-heroalt: Zach pointing to the new balloons in his office that say 8 Million
-herocaption: Eight Million Eleventy npm Downloads!
-herolink: https://www.11ty.dev/blog/eight-million/
+hero: https://o.famebot.com/file/famebot/eleventeen.png
+heroalt: screenshot
+herocaption: latest eleventeen
+herolink: /about/
 tags:
   - second tag
   - posts with two tags

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import markdownItAnchor from "markdown-it-anchor";
+import { IdAttributePlugin } from "@11ty/eleventy";
 import pluginRss from "@11ty/eleventy-plugin-rss";
 import pluginSyntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
 import pluginBundle from "@11ty/eleventy-plugin-bundle";
@@ -29,6 +29,7 @@ export default async function(eleventyConfig) {
 
 	// Official plugins
 	eleventyConfig.addPlugin(pluginRss);
+	eleventyConfig.addPlugin(IdAttributePlugin);
 	eleventyConfig.addPlugin(pluginSyntaxHighlight, {
 		preAttributes: { tabindex: 0 },
 	});
@@ -79,20 +80,6 @@ export default async function(eleventyConfig) {
 		return (tags || []).filter(
 			(tag) => ["all", "nav", "post", "posts"].indexOf(tag) === -1
 		);
-	});
-
-	// Customize Markdown library settings:
-	eleventyConfig.amendLibrary("md", (mdLib) => {
-		mdLib.use(markdownItAnchor, {
-			permalink: markdownItAnchor.permalink.ariaHidden({
-				placement: "after",
-				class: "header-anchor",
-				symbol: "#",
-				ariaHidden: false,
-			}),
-			level: [1, 2, 3, 4],
-			slugify: eleventyConfig.getFilter("slugify"),
-		});
 	});
 
 	eleventyConfig.addShortcode("currentBuildDate", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eleventeen",
-	"version": "9.2.19-alpha.16",
+	"version": "9.2.20-alpha.17",
 	"description": "Starter repository for a website built with Eleventy + eleventeen",
 	"type": "module",
 	"scripts": {
@@ -39,14 +39,13 @@
 	},
 	"homepage": "https://eleventeen.blog/about/",
 	"devDependencies": {
-		"@11ty/eleventy": "3.0.0-alpha.16",
+		"@11ty/eleventy": "3.0.0-alpha.17",
 		"@11ty/eleventy-img": "^4.0.2",
 		"@11ty/eleventy-navigation": "^0.3.5",
 		"@11ty/eleventy-plugin-bundle": "^2.0.2",
-		"@11ty/eleventy-plugin-rss": "^2.0.1",
+		"@11ty/eleventy-plugin-rss": "^2.0.2",
 		"@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
 		"@famebot/chromagen": "^1.0.1",
-		"luxon": "^3.4.4",
-		"markdown-it-anchor": "^9.0.1"
+		"luxon": "^3.4.4"
 	}
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -436,7 +436,7 @@ header {
 	margin-inline-end: 1em;
 }
 
-/* Direct Links / Markdown Headers */
+/* Direct Links / Markdown Headers
 .header-anchor {
 	text-decoration: none;
 	font-style: normal;
@@ -462,3 +462,4 @@ a.header-anchor:focus,
 h2 + .header-anchor {
 	font-size: 1.5em;
 }
+*/


### PR DESCRIPTION
- use new IdAttributePlugin, makes “use of the existing posthtml infrastructure used by the HTML base plugin and the input path to URL plugins to add” slugified `id` attrs. “Has the added benefit of removing the unnecessary link markup from your RSS feeds too!” https://github.com/11ty/eleventy/issues/3363
- rm markdownItAnchor and comment out header-anchor css
- eleventeen.png instead of eight-million.jpg in thirdpost.md
- upd eleventy + eleventy-plugin-rss

9.2.20-alpha.17