### PR TITLE
async heading-anchors, prevent FOAT, housekeeping

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -49,7 +49,7 @@ heading-anchors a[href^="#"]:hover::before {
 	color: var(--text-color-link-highlight);
 	text-decoration: underline;
 }
-			{% endcss %}
+		{% endcss %}
 		{#- Add the contents of a file to the bundle #}
 		{%- css %}{% include "public/css/index.css" %}{% endcss %}
 		
@@ -186,8 +186,6 @@ activateColorScheme();
 			{% endjs %}
 			{% endif %}
 
-			<script type="module" src="/js/heading-anchors.js"></script>
-
 			{#
 				getBundleFileUrl Writes the bundle content to a content-hashed file location in your 
 				output directory and returns the URL to the file for use.
@@ -203,6 +201,7 @@ activateColorScheme();
 				prefers-color-scheme initial preference and changes
 			#}
 			<script async src="{% getBundleFileUrl "js" %}"></script>
+			<script async type="module" src="/js/heading-anchors.js"></script>
 		</div>
 	</body>
 </html>

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -264,6 +264,12 @@ main img {
 	max-width: 100%;
 }
 
+main img,
+main img::before {
+	color: transparent;
+	font-size: 0;
+}
+
 footer,
 header {
 	padding: 1rem;


### PR DESCRIPTION
* 8100561 color transparent and font-size 0 for main img
  prevents loading FOAT! Flash of alt text
* 6e319e2 async heading-anchors.js
  > As with regular scripts, `async` causes the script to download without
  > blocking the HTML parser and executes as soon as possible. Unlike
  > regular scripts, `async` also works on inline modules.
  https://jakearchibald.com/2017/es-modules-in-browsers/#async-works-on-external--inline-modules
* 213c75a clean up config, combine imports
* 75bd941 alpha to beta, edit for brevity